### PR TITLE
Antireach, FixedContainer & Stuffs

### DIFF
--- a/Behavior/scripts/example/commands/import-commands.js
+++ b/Behavior/scripts/example/commands/import-commands.js
@@ -17,3 +17,4 @@ import './staff/dev.js';
 import './staff/punish.js';
 import './staff/eval.js';
 import './staff/inv.js';
+import './staff/antireach.js';

--- a/Behavior/scripts/example/commands/import-commands.js
+++ b/Behavior/scripts/example/commands/import-commands.js
@@ -18,3 +18,4 @@ import './staff/punish.js';
 import './staff/eval.js';
 import './staff/inv.js';
 import './staff/antireach.js';
+import './staff/fixedcontainer.js';

--- a/Behavior/scripts/example/commands/import-commands.js
+++ b/Behavior/scripts/example/commands/import-commands.js
@@ -13,4 +13,5 @@ import './staff/setworldspawn.js';
 //import './staff/inventoryview.js';
 import './staff/dev.js';
 import './staff/punish.js';
+import './staff/eval.js';
 import './staff/inv.js';

--- a/Behavior/scripts/example/commands/import-commands.js
+++ b/Behavior/scripts/example/commands/import-commands.js
@@ -1,4 +1,6 @@
 import './information/help.js';
+import './information/tpsi.js'
+
 import './other/home.js';
 import './other/lastdeath.js';
 import './other/selfstats.js';

--- a/Behavior/scripts/example/commands/import-commands.js
+++ b/Behavior/scripts/example/commands/import-commands.js
@@ -10,6 +10,7 @@ import './other/suicide.js';
 import './other/vipm.js';
 
 import './staff/setworldspawn.js';
-import './staff/inventoryview.js';
+//import './staff/inventoryview.js';
 import './staff/dev.js';
 import './staff/punish.js';
+import './staff/inv.js';

--- a/Behavior/scripts/example/commands/information/tpsi.js
+++ b/Behavior/scripts/example/commands/information/tpsi.js
@@ -1,0 +1,34 @@
+//@ts-check
+import { world } from 'mojang-minecraft';
+import { Server } from '../../../library/Minecraft.js';
+
+const registerInformation = {
+    cancelMessage: true,
+    name: 'tps',
+    staff: 'true',
+    description: 'Shows TPS',
+    usage: '',
+    example: [
+        'tps'
+    ]
+};
+
+Server.command.register(registerInformation, (chatmsg, args) => {
+    const {sender} = chatmsg
+
+    const latestTPS = tpsarr[tpsarr.length - 1] ?? 20,
+        size = tpsarr.length,
+        avgTPS = tpsarr.reduce((a, b) => a + b, 0) / size,
+        minTPS = Math.min(...tpsarr)
+
+    sender.tellraw(`Server TPS: §a${latestTPS.toFixed(2)}§r (Average: §a${avgTPS.toFixed(2)}§r, Min: §a${minTPS.toFixed(2)}§r)`)
+});
+
+let stress = 0,
+    tpsarr = []
+
+world.events.tick.subscribe(({deltaTime}) => {
+    const tps = 1 / deltaTime
+    tpsarr.push(tps)
+    tpsarr.splice(0, Math.max( ~~Math.min( tpsarr.length - tps, tpsarr.length - 1 ), 0) )
+})

--- a/Behavior/scripts/example/commands/staff/antireach.js
+++ b/Behavior/scripts/example/commands/staff/antireach.js
@@ -1,0 +1,86 @@
+//@ts-check
+import { Player, world as World } from 'mojang-minecraft';
+import { Server } from '../../../library/Minecraft.js';
+import area from '../../../library/utils/area.js';
+import { tellrawStaff } from '../../../library/utils/prototype.js';
+import scoreboard from '../../../library/utils/scoreboard.js';
+
+const registerInformation = {
+    cancelMessage: true,
+    name: 'antireach',
+    staff: 'true',
+    description: 'Manages AntiReach module',
+    usage: '',
+    example: [
+        'antireach on',
+        'antireach off',
+        'antireach max-dist 6.100',
+    ]
+};
+
+const obj = scoreboard.objective.for('antireach').dummies.useCache(false)
+if (!obj.has('toggle')) obj.set('toggle', 1)
+if (!obj.has('max_dist')) obj.set('max_dist', 6000)
+
+// note that this is multiplied by 1000 to support decimals.
+let maxdist = obj.get('max_dist')
+
+let toggle = obj.get('toggle')
+
+Server.command.register(registerInformation, (chatmsg, args) => {
+    const {sender} = chatmsg
+
+    if (!sender.hasTag('staffstatus')) return sender.tellraw(`§¶§cUAC ► §c§lError 4: Only Staff can use this command`)
+
+    switch (args[0]) {
+        case undefined:
+            return sender.tellraw(`§eAnti-Reach§f: ${toggle ? '§aENABLED' : '§cDISABLED'}`);
+        case 'enable':
+        case 'on': {
+            obj.set('toggle', 1)
+            toggle = 1
+            sender.tellraw(`§eAnti-Reach§f has been §aENABLED§r.`);
+            tellrawStaff(`§¶§cUAC ► §bPlayer §d${sender.name}§b toggles the §eAnti-Reach§f module to §aENABLED§r.`);
+        }
+
+        case 'disable':
+        case 'off': {
+            obj.set('toggle', 0)
+            toggle = 0
+            sender.tellraw(`§eAnti-Reach§f has been §cDISABLED§r.`);
+            tellrawStaff(`§¶§cUAC ► §bPlayer §d${sender.name}§b toggles the §eAnti-Reach§f module to §cDISABLED§r.`);
+        }
+
+        case 'max':
+        case 'maxdist':
+        case 'max-dist':
+        case 'maxreach':
+        case 'max-reach': {
+            if (!args[1]) return sender.tellraw(`Max reach: §a${maxdist / 1000}`);
+
+            const newValue = ~~(Number(args[1]) * 1000);
+            if (!isFinite(newValue)) return sender.tellraw(`§¶§cUAC ► §c§lError 7: ${args[1]} is not a number`);
+
+            maxdist = newValue;
+            obj.set('max_dist', newValue)
+
+            sender.tellraw(`Max reach has been set to §a${(newValue / 1000).toFixed(3)}`);
+            tellrawStaff(`§¶§cUAC ► §bPlayer §d${sender.name}§b has set the max reach to §a${(newValue / 1000).toFixed(3)}§r`);
+            return;
+        }
+        default:
+            return sender.tellraw(`§¶§cUAC ► §c§lError 7: command failure`);
+    }
+});
+
+const playerCollisionSize = [0.6, 1.2, 0.6]
+
+World.events.entityHit.subscribe(({entity: plr, hitEntity: target}) => {
+    if (!( toggle && plr instanceof Player && target && target instanceof Player && plr.hasTag('staffstatus') )) return
+
+    const areaData = area.bindLocation(target.location, playerCollisionSize),
+        distarr = areaData.getDistanceWithLocation(plr.headLocation),
+        dist = Math.hypot(...distarr)
+    
+    if (dist > (maxdist / 1000)) tellrawStaff(`§¶§cUAC ► §bPlayer §d${plr.name}§b has §chigh reach§b detected (§c${dist.toFixed(3)}§b)`)
+})

--- a/Behavior/scripts/example/commands/staff/antireach.js
+++ b/Behavior/scripts/example/commands/staff/antireach.js
@@ -73,7 +73,7 @@ Server.command.register(registerInformation, (chatmsg, args) => {
     }
 });
 
-const playerCollisionSize = [0.6, 1.2, 0.6]
+const playerCollisionSize = [0.3, 1.8, 0.3]
 
 World.events.entityHit.subscribe(({entity: plr, hitEntity: target}) => {
     if (!( toggle && plr instanceof Player && target && target instanceof Player && plr.hasTag('staffstatus') )) return

--- a/Behavior/scripts/example/commands/staff/eval.js
+++ b/Behavior/scripts/example/commands/staff/eval.js
@@ -1,0 +1,212 @@
+import { Server } from '../../../library/Minecraft.js';
+
+import * as mc from 'mojang-minecraft'
+import * as gt from 'mojang-gametest'
+import * as mcui from 'mojang-minecraft-ui'
+
+import * as mclib from '../../../library/Minecraft.js';
+import { Command as commandBuilder } from '../../../library/build/classes/commandBuilder.js';
+import { EventEmitter as eventEmitter } from '../../../library/build/classes/eventEmitter.js';
+import { Server as serverBuilder } from '../../../library/build/classes/serverBuilder.js';
+import * as chatrank from '../../../library/miscellaneous/chatrank.js';
+import * as leaderboard from '../../../library/miscellaneous/leaderboard.js';
+import * as prototype from '../../../library/utils/prototype.js';
+import scoreboard from '../../../library/utils/scoreboard.js';
+
+const registerInformation = {
+    cancelMessage: true,
+    name: 'eval',
+    private: 'true',
+    description: 'developer commands',
+    usage: '[ script ]',
+    example: [
+    ]
+};
+
+let cmd
+const globalBind = new Proxy({
+    modules: (() => {
+        const x = {
+            mc,
+            gt,
+            mcui
+        }
+        return new Proxy(Object.create(null), {
+            get: (t, p) => x[p],
+            set: (t, p, v) => true,
+            has: (t, p) => p in x
+        })
+    })(),
+    mclib,
+    builder: {
+        eventEmitter,
+        serverBuilder,
+    },
+    misc: {
+        chatrank,
+        leaderboard,
+        prototype,
+        scoreboard
+    },
+    get cmd() { return cmd; },
+}, {
+    get: (t, p) => p in t ? t[p] : globalThis[p],
+    has: (t, p) => true
+});
+
+const viewObj = (() => {
+    const GeneratorFunction = Object.getPrototypeOf(function* () { }).constructor, errUnknown = '§c[Unknown]§r', defTab = ' §8:§r ', defStrEscDict = {
+        '\t': 'TAB',
+        '\v': 'VTAB',
+        '\r': 'CR',
+        '\n': 'LF',
+        '\f': 'FF',
+        '\0': 'NUL',
+    }, defStrColorDict = {
+        '§0': 'BLACK',
+        '§1': 'DBLUE',
+        '§2': 'DGRN',
+        '§3': 'DAQUA',
+        '§4': 'DRED',
+        '§5': 'DPURP',
+        '§6': 'GOLD',
+        '§7': 'GRAY',
+        '§8': 'DGRAY',
+        '§9': 'BLUE',
+        '§a': 'GRN',
+        '§b': 'AQUA',
+        '§c': 'RED',
+        '§d': 'PURP',
+        '§e': 'YLW',
+        '§f': 'WHITE',
+        '§g': 'GOLD',
+    }, defStrFormatDict = {
+        '§k': 'OBF',
+        '§l': 'BOLD',
+        '§o': 'RESET',
+        '§r': 'ITLC',
+    };
+    const keyFormat = (k) => typeof k == 'symbol' ? `§a${String(k)}§r` : k[0] == '_' ? `§7${k}§r` : k;
+    const exec = (obj, tab = defTab, objlist = [], addObj = obj) => {
+        if (objlist.includes(obj))
+            return '§b[Circular]';
+        if (obj === null || obj === undefined)
+            return `§8${obj}`;
+        const objConstructor = Object.getPrototypeOf(obj)?.constructor, constructorIsObject = objConstructor === Object || objConstructor == null;
+        const o = [];
+        const prevTab = tab.slice(0, -defTab.length);
+        const kv = (k) => {
+            const headings = `${tab} ${keyFormat(k)}${getGetterSetter(k)}: `;
+            try {
+                return headings + exec(obj[k], tab + defTab, objlist.concat([addObj]), obj[k]);
+            }
+            catch {
+                return headings + errUnknown;
+            }
+        }, getKeys = () => {
+            if (constructorIsObject) {
+                return new Set(Reflect.ownKeys(obj));
+            }
+            else {
+                const o = new Set(objConstructor == Function ? Reflect.ownKeys(obj)
+                    : Reflect.ownKeys(objConstructor.prototype).filter(v => v in obj).concat(Reflect.ownKeys(obj)));
+                o.delete('length');
+                o.delete('name');
+                o.delete('arguments');
+                o.delete('caller');
+                o.delete('prototype');
+                o.delete('constructor');
+                return o;
+            }
+        }, getGetterSetter = (k) => {
+            const { get, set } = Reflect.getOwnPropertyDescriptor(obj, k)
+                ?? (k in obj ? Reflect.getOwnPropertyDescriptor(objConstructor.prototype, k) : null)
+                ?? {};
+            return get && set ? ` §b[Get/Set]§r `
+                : get ? ` §b[Get]§r `
+                    : set ? ` §b[Set]§r `
+                        : '';
+        };
+        try {
+            switch (objConstructor) {
+                case String:
+                    return `§7"§r${obj.replace(/[\t\r\n\v\f\0]|§./g, (v) => v in defStrEscDict ? `§d[${defStrEscDict[v]}]§r` : v in defStrColorDict ? `§b[${defStrColorDict[v]}]§r` : v in defStrFormatDict ? `§a[${defStrFormatDict[v]}]§r` : `§8[S${v.slice(-1)}]§r`)}§7"§r`;
+                case Number:
+                    return `§a${obj}§r`;
+                case Boolean:
+                    return `§a${obj}§r`;
+                case RegExp:
+                    return `§c${obj}§r`;
+                case Symbol:
+                    return `§b${String(obj)}§r`;
+                case GeneratorFunction:
+                case Function: {
+                    let l = 0;
+                    if (obj.prototype)
+                        l++;
+                    if (!(Object.getOwnPropertyDescriptor(obj, 'prototype')?.writable ?? true))
+                        l++;
+                    const cn = obj.name || '(anonymous)';
+                    o.push(objConstructor == GeneratorFunction ? `§e[GeneratorFunction: ${cn}]§r`
+                        : l == 0 || l == 1 ? `§e[Function: ${cn}]§r`
+                            : l == 2 ? `§b[Class: ${cn}]§r`
+                                : '');
+                    const keys = getKeys();
+                    if (keys.size) {
+                        o[0] += ' {';
+                        for (const k of keys)
+                            o.push(kv(k));
+                        o.push(`${prevTab} }`);
+                    }
+                    return o.join('\n§r');
+                }
+                case Array: {
+                    if (!obj.length)
+                        return `[] §7Array<0>`;
+                    o.push(`[ §7Array<${obj.length}>`);
+                    for (const k in obj)
+                        o.push(kv(k));
+                    o.push(`${prevTab} ]`);
+                    return o.join('\n§r');
+                }
+                default: {
+                    const constructorName = objConstructor?.name ?? '[Object: null prototype]';
+                    const keys = getKeys();
+                    if (!keys.size)
+                        return `{} §7${constructorName}`;
+                    o.push(`{ §7${constructorName}`);
+                    for (const k of keys)
+                        o.push(kv(k));
+                    o.push(`${prevTab} }`);
+                    return o.join('\n§r');
+                }
+            }
+        }
+        catch {
+            return errUnknown;
+        }
+    };
+    return (obj) => exec(obj);
+})();
+
+Server.command.register(registerInformation, (chatmsg, args) => {
+    try {
+        const { sender } = chatmsg;
+        const message = chatmsg.message.substring(4 + commandBuilder.prefix.length + 1)
+        const tellraw = (v) => sender.runCommand(`tellraw @s {"rawtext":[{"text":"${v.replaceAll(/\\|"/g, '\\$&')}"}]}`)
+        
+        if (!sender.hasTag('staffstatus')) return tellraw(`§¶§cUAC ► §c§lError 4: Only Staff can use this command`)
+
+        tellraw(`> ${message}`);
+        try {
+            cmd = { evd: chatmsg, args };
+            new Function(`with (this) {\nthrow ${message}\n}`).call(globalBind);
+        } catch (e) {
+            if (e instanceof Error) tellraw(`${e}\n${e.stack}`);
+            else tellraw(viewObj(e));
+            tellraw(' ');
+        }
+    } catch(e) {
+        console.warn(`${e}\n${e.stack}`)
+    }
+});

--- a/Behavior/scripts/example/commands/staff/fixedcontainer.js
+++ b/Behavior/scripts/example/commands/staff/fixedcontainer.js
@@ -1,0 +1,96 @@
+//@ts-check
+import { BlockLocation, Dimension, Location, world} from 'mojang-minecraft';
+import { Server } from '../../../library/Minecraft.js';
+import { tellrawStaff } from '../../../library/utils/prototype.js';
+import scoreboard from '../../../library/utils/scoreboard.js';
+
+const registerInformation = {
+    cancelMessage: true,
+    name: 'fixedcontainer',
+    staff: 'true',
+    description: 'Manages FixedContainer module',
+    usage: '',
+    example: [
+        'fixedcontainer on',
+        'fixedcontainer off'
+    ]
+};
+
+const obj = scoreboard.objective.for('fixedcontainer').dummies.useCache(false)
+if (!obj.has('toggle')) obj.set('toggle', 1)
+
+let toggle = obj.get('toggle')
+
+Server.command.register(registerInformation, (chatmsg, args) => {
+    const {sender} = chatmsg
+
+    if (!sender.hasTag('staffstatus')) return sender.tellraw(`§¶§cUAC ► §c§lError 4: Only Staff can use this command`)
+
+    switch (args[0]) {
+        case undefined:
+            return sender.tellraw(`§eFixedContainer§f: ${toggle ? '§aENABLED' : '§cDISABLED'}`);
+        case 'enable':
+        case 'on': {
+            obj.set('toggle', 1)
+            toggle = 1
+            sender.tellraw(`§eFixedContainer§f has been §aENABLED§r.`);
+            tellrawStaff(`§¶§cUAC ► §bPlayer §d${sender.name}§b toggles the §eFixedContainer§f module to §aENABLED§r.`);
+        }
+
+        case 'disable':
+        case 'off': {
+            obj.set('toggle', 0)
+            toggle = 0
+            sender.tellraw(`§eFixedContainer§f has been §cDISABLED§r.`);
+            tellrawStaff(`§¶§cUAC ► §bPlayer §d${sender.name}§b toggles the §eFixedContainer§f module to §cDISABLED§r.`);
+        }
+
+        default:
+            return sender.tellraw(`§¶§cUAC ► §c§lError 7: command failure`);
+    }
+});
+/** @type { (d: Dimension, v: string) => void } */
+const rc = (d, v) => { try { d.runCommand(v) } catch {} }
+const { floor } = Math
+/** @type { (v: [number, number, number] | Location | BlockLocation) => [number, number, number] } */
+const posify = (v) => Array.isArray(v) ? v : [floor(v.x), floor(v.y), floor(v.z)];
+/** @type { (v: [number, number, number] | Location | BlockLocation) => string } */
+const posConvert = (v) => posify(v).map(v => `§a${v}§r`).join(', ');
+
+const fixes = {
+    'minecraft:furnace': 0,
+    'minecraft:blast_furnace': 0,
+    'minecraft:smoker': 0,
+    'minecraft:dispenser': 0,
+    'minecraft:dropper': 0,
+    'minecraft:hopper': 0,
+    'minecraft:chest': 0,
+    'minecraft:trapped_chest': 0,
+};
+world.events.blockPlace.subscribe(({ block, player: plr, dimension: dim }) => {
+    if (!(toggle && !plr.hasTag('staffstatus') && block.id in fixes)) return;
+
+    const { location, id, permutation } = block;
+    const pos = posify(location), [x, y, z] = pos, posStr = pos.join(' ');
+
+    if (id == 'minecraft:chest' || id == 'minecraft:trapped_chest') {
+        const c = block.getComponent('inventory').container;
+        for (let m = c.size, i = m - 27; i < m; i++) {
+            const item = c.getItem(i);
+            if (!item) continue;
+
+            tellrawStaff(`§¶§cUAC ► §cNon-empty ${id}§r placed by §b${plr.name}§r in ${posConvert(block.location)}`);
+            const slc = `x=${x}, y=${y}, z=${z}, dx=0, dy=0, dz=0, type=item`;
+            rc(dim, `tag @e[${slc}] add tmp`);
+            rc(dim, `setblock ${posStr} air 0 destroy`);
+            rc(dim, `kill @e[${slc}, tag=!tmp]`);
+            rc(dim, `tag @e[${slc}, tag=tmp] remove tmp`);
+            break;
+        }
+    }
+    else {
+        rc(dim, `setblock ${posStr} air`);
+        rc(dim, `setblock ${posStr} ${id}`);
+        block.setPermutation(permutation);
+    }
+});

--- a/Behavior/scripts/example/commands/staff/inv.js
+++ b/Behavior/scripts/example/commands/staff/inv.js
@@ -1,0 +1,65 @@
+//@ts-check
+import { ItemStack, MinecraftItemTypes, Player, PlayerInventoryComponentContainer, world } from 'mojang-minecraft';
+import { Server } from '../../../library/Minecraft.js';
+
+const registerInformation = {
+    cancelMessage: true,
+    name: 'inv',
+    staff: 'true',
+    description: 'Manages inventory',
+    usage: '',
+    example: [
+        'inv save',
+        'inv load',
+        'inv clone "Player Name"',
+    ]
+};
+
+const air = new ItemStack(MinecraftItemTypes.air, 0)
+
+/** @type { Map<Player, {inv:ItemStack[],ss:number}> } */
+let invData = new Map()
+
+Server.command.register(registerInformation, (chatmsg, args) => {
+    const {sender} = chatmsg
+
+    if (!sender.hasTag('staffstatus')) return sender.tellraw(`§¶§cUAC ► §c§lError 4: Only Staff can use this command`)
+
+    /** @type {PlayerInventoryComponentContainer} */
+    const c = sender.getComponent('inventory').container
+
+    switch (args[0]) {
+        case 'save': {
+            invData.set(sender, { inv: Array.from(Array(c.size), (v, i) => c.getItem(i) ?? air), ss: sender.selectedSlot })
+
+            return sender.tellraw(`§bInventory saved. To load your inventory, do §aUAC.inv load§r`);
+        }
+
+        case 'load': {
+            const { inv, ss } = invData.get(sender) ?? {}
+            if (!inv) return sender.tellraw(`§¶§cUAC ► §c§lError: You don't have your inventory saved.`);
+
+            for (let i = 0, m = c.size; i < m; i++) c.setItem(i, inv[i])
+            sender.selectedSlot = ss
+
+            return sender.tellraw(`§bInventory loaded.`);
+        }
+
+        case 'clone': {
+            const targetName = args[1]
+            // @ts-ignore
+
+            const target = [...world.getPlayers()].find(player => player.getName() === targetName);
+            if (!target) return sender.tellraw(`§¶§cUAC ► §c§lError: Player not found`);
+            const tc = target.getComponent('inventory').container
+
+            for (let i = 0, m = c.size; i < m; i++) c.setItem(i, tc.getItem(i) ?? air)
+            sender.selectedSlot = target.selectedSlot
+
+            return sender.tellraw(`§bCloned §d${target.name}§b's inventory.`);
+        }
+
+        default:
+            return sender.tellraw(`§¶§cUAC ► §c§lError 7: command failure`);
+    }
+});

--- a/Behavior/scripts/library/utils/area.js
+++ b/Behavior/scripts/library/utils/area.js
@@ -1,0 +1,118 @@
+const rearrange = (a, b) => {
+    if (a.every((v, i) => b[i] > v))
+        return [a, b];
+    if (a.every((v, i) => b[i] < v))
+        return [b, a];
+    const arr = [[0, 0, 0], [0, 0, 0]];
+    for (let i = 0; i < 3; i++) {
+        const av = a[i], bv = b[i];
+        const reverse = bv > av;
+        arr[reverse ? 0 : 1][i] = av;
+        arr[reverse ? 1 : 0][i] = bv;
+    }
+    return arr;
+};
+const axisEnum = {
+    x: 0,
+    y: 1,
+    z: 2
+};
+export default class area {
+    static bindLocation = (location, centerSize) => {
+        location = posifyDecimal(location);
+        centerSize = posifyDecimal(centerSize);
+        const start = location.map((v, i) => v - centerSize[i]);
+        const end = location.map((v, i) => v + centerSize[i]);
+        return new area(start, end);
+    };
+    [Symbol.iterator] = (() => {
+        const t = this;
+        return function* () {
+            const [[xmin, ymin, zmin], [xmax, ymax, zmax]] = rearrange(t.start, t.end);
+            for (let x = xmin; x <= xmax; x++)
+                for (let y = ymin; y <= ymax; y++)
+                    for (let z = zmin; z <= zmax; z++)
+                        yield [~~x, ~~y, ~~z];
+        };
+    })();
+    start;
+    end;
+    expand = (size = 1) => {
+        this.start = this.start.map(v => v - size);
+        this.end = this.end.map(v => v + size);
+        return this;
+    };
+    expandAxis = (axis, size = 1) => {
+        axis = typeof axis == 'string' ? axisEnum[axis] : axis;
+        this.start[axis] - size;
+        this.end[axis] + size;
+        return this;
+    };
+    shrink = (size = 1) => {
+        this.start = this.start.map(v => v + size);
+        this.end = this.end.map(v => v - size);
+        return this;
+    };
+    shrinkAxis = (axis, size = 1) => {
+        axis = typeof axis == 'string' ? axisEnum[axis] : axis;
+        this.start[axis] + size;
+        this.end[axis] - size;
+        return this;
+    };
+    fix = () => {
+        [this.start, this.end] = rearrange(this.start, this.end);
+        return this;
+    };
+    getCenterSize = () => this.start.map((v, i) => (this.end[i] - v) / 2);
+    getCenterLocation = () => this.start.map((v, i) => (this.end[i] + v) / 2);
+    getSize = () => this.start.map((v, i) => this.end[i] - v);
+    getAreas = (size) => {
+        size = posifyDecimal(size);
+        const { abs, min } = Math;
+        const [xa, ya, za] = (typeof size == 'number' ? [size, size, size] : size).map(abs);
+        const [[xmin, ymin, zmin], [xmax, ymax, zmax]] = rearrange(this.start, this.end);
+        return (function* () {
+            for (let x = xmin; x <= xmax; x += xa) {
+                for (let y = ymin; y <= ymax; y += ya) {
+                    for (let z = zmin; z <= zmax; z += za) {
+                        const xcmax = min(x + xa - 1, xmax), ycmax = min(y + ya - 1, ymax), zcmax = min(z + za - 1, zmax);
+                        yield [
+                            [~~x, ~~y, ~~z],
+                            [~~xcmax, ~~ycmax, ~~zcmax]
+                        ];
+                    }
+                }
+            }
+        })();
+    };
+    getDistanceWithLocation = (location) => {
+        location = posifyDecimal(location);
+        const [min, max] = rearrange(this.start, this.end);
+        return Array.from(Array(3), (v, i) => location[i] < min[i] ? min[i] - location[i] : location[i] > max[i] ? location[i] - max[i] : 0);
+    };
+    getDistanceWithArea = (area) => {
+        const [min0, max0] = rearrange(this.start, this.end);
+        const [min1, max1] = rearrange(area.start, area.end);
+        const [min, max] = [[min0, min1], [max0, max1]];
+        return Array.from(Array(3), (v, i) => {
+            const [a, b, c, d] = [
+                min[0][i] - min[1][i],
+                min[0][i] - max[1][i],
+                min[1][i] - max[0][i],
+                max[1][i] - max[0][i]
+            ];
+            return (a >= 0 && b <= 0) || (c <= 0 && d >= 0) ? 0
+                : (a >= 0 && b >= 0) ? Math.min(a, b) : Math.min(c, d);
+        });
+    };
+    constructor(start, end) {
+        start = posifyDecimal(start);
+        end = posifyDecimal(end);
+        this.start = start;
+        this.end = end;
+    }
+}
+const { floor } = Math;
+export const posify = (v) => Array.isArray(v) ? v : [floor(v.x), floor(v.y), floor(v.z)];
+export const posifyDecimal = (v) => Array.isArray(v) ? v : [v.x, v.y, v.z];
+export const posConvert = (v) => posify(v).map(v => `§a${v}§r`).join(', ');

--- a/Behavior/scripts/library/utils/scoreboard.js
+++ b/Behavior/scripts/library/utils/scoreboard.js
@@ -45,13 +45,13 @@ class players {
         this.set = (plr, score) => {
             if (useCache)
                 cacheData.set(plr, score);
-            execCmd(`scoreboard players set @s ${obj.executableId} ${score}`, plr);
+            execCmd(`scoreboard players set @s ${obj.executableId} ${~~score}`, plr);
             return this;
         };
         this.add = (plr, score) => {
             if (useCache)
                 cacheData.set(plr, (cacheData.get(plr) ?? 0) + score);
-            execCmd(`scoreboard players add @s ${obj.executableId} ${score}`, plr);
+            execCmd(`scoreboard players add @s ${obj.executableId} ${~~score}`, plr);
             return this;
         };
         /** @returns {number} */
@@ -107,13 +107,13 @@ class dummies {
         this.set = (dummy, score) => {
             if (useCache)
                 cacheData[dummy] = score;
-            execCmd(`scoreboard players set ${nameToExecutable(dummy)} ${score}`);
+            execCmd(`scoreboard players set ${nameToExecutable(dummy)} ${~~score}`);
             return this;
         };
         this.add = (dummy, score) => {
             if (useCache)
                 cacheData[dummy] = cacheData[dummy] ?? 0 + score;
-            execCmd(`scoreboard players add ${nameToExecutable(dummy)} ${score}`);
+            execCmd(`scoreboard players add ${nameToExecutable(dummy)} ${~~score}`);
             return this;
         };
         /** @returns {number} */

--- a/Behavior/scripts/library/utils/scoreboard.js
+++ b/Behavior/scripts/library/utils/scoreboard.js
@@ -1,0 +1,230 @@
+import { world } from "mojang-minecraft";
+
+class CommandError extends Error {
+    code
+    command
+    constructor(code, message, command) {
+        super(message)
+        this.code = code
+        this.command = command
+        this.name = this.constructor.name
+        this.message += `\nCode: ${code}  -  Command: ${command}`
+        this.stack = this.stack.replace(/.*\n?/, '')
+    }
+}
+
+const execCmd = (command, source = 'overworld') => {
+    try {
+        return (typeof source == 'string' ? world.getDimension(source) : source).runCommand(command);
+    }
+    catch (e) {
+        if (e instanceof Error)
+            throw e;
+        const { statusCode, statusMessage } = JSON.parse(e);
+        throw new CommandError(statusCode, statusMessage, command);
+    }
+};
+const empty = (obj) => Object.defineProperties(Object.create(null), Object.getOwnPropertyDescriptors(obj ?? {}));
+
+const auth = Symbol();
+const toExecutable = (v) => `"${v.replace(/\\|"/g, '\\$&')}"`;
+class players {
+    useCache;
+    'set';
+    add;
+    'get';
+    has;
+    reset;
+    dummies;
+    constructor(key, obj) {
+        if (key !== auth)
+            throw new ReferenceError('Class is not constructable');
+        let cacheData = new Map(), useCache = true;
+        Object.defineProperty(this, 'dummies', { get: () => obj.dummies });
+        this.useCache = (set) => (useCache = set, this);
+        this.set = (plr, score) => {
+            if (useCache)
+                cacheData.set(plr, score);
+            execCmd(`scoreboard players set @s ${obj.executableId} ${score}`, plr);
+            return this;
+        };
+        this.add = (plr, score) => {
+            if (useCache)
+                cacheData.set(plr, (cacheData.get(plr) ?? 0) + score);
+            execCmd(`scoreboard players add @s ${obj.executableId} ${score}`, plr);
+            return this;
+        };
+        /** @returns {number} */
+        this.get = (plr) => {
+            let o;
+            if (useCache)
+                o = cacheData.get(plr);
+            if (o == undefined) {
+                try {
+                    o = +execCmd(`scoreboard players test @s ${obj.executableId} * *`, plr).statusMessage.match(/-?\d+/)[0];
+                }
+                catch { }
+                if (o != undefined)
+                    cacheData.set(plr, o);
+            }
+            return o;
+        };
+        this.has = (plr) => {
+            try {
+                execCmd(`scoreboard players test @s ${obj.executableId} * *`, plr);
+                return true;
+            }
+            catch {
+                return false;
+            }
+        };
+        this.reset = (plr) => {
+            if (useCache)
+                cacheData.delete(plr);
+            try {
+                execCmd(`scoreboard players reset @s ${obj.executableId}`, plr);
+            }
+            catch { }
+            return this;
+        };
+    }
+}
+class dummies {
+    useCache;
+    'set';
+    add;
+    'get';
+    has;
+    reset;
+    players;
+    constructor(key, obj) {
+        if (key !== auth)
+            throw new ReferenceError('Class is not constructable');
+        let cacheData = empty(), useCache = true;
+        Object.defineProperty(this, 'players', { get: () => obj.players });
+        const nameToExecutable = (v) => `${toExecutable(v)} ${obj.executableId}`;
+        this.useCache = (set) => (useCache = set, this);
+        this.set = (dummy, score) => {
+            if (useCache)
+                cacheData[dummy] = score;
+            execCmd(`scoreboard players set ${nameToExecutable(dummy)} ${score}`);
+            return this;
+        };
+        this.add = (dummy, score) => {
+            if (useCache)
+                cacheData[dummy] = cacheData[dummy] ?? 0 + score;
+            execCmd(`scoreboard players add ${nameToExecutable(dummy)} ${score}`);
+            return this;
+        };
+        /** @returns {number} */
+        this.get = (dummy) => {
+            let o;
+            if (useCache)
+                o = cacheData[dummy];
+            if (o == undefined) {
+                try {
+                    o = +execCmd(`scoreboard players test ${nameToExecutable(dummy)} * *`).statusMessage.match(/-?\d+/)[0];
+                }
+                catch { }
+                if (o != undefined)
+                    cacheData[dummy] = o;
+            }
+            return o;
+        };
+        this.has = (dummy) => {
+            try {
+                execCmd(`scoreboard players test ${nameToExecutable(dummy)} * *`);
+                return true;
+            }
+            catch {
+                return false;
+            }
+        };
+        this.reset = (plr) => {
+            if (useCache)
+                delete cacheData[plr];
+            try {
+                execCmd(`scoreboard players reset ${nameToExecutable(plr)}`);
+            }
+            catch { }
+            return this;
+        };
+    }
+}
+class objective {
+    static create = (id, displayName = id) => new objective(id, displayName, false);
+    static edit = (id) => new objective(id, '', true);
+    static exist = (id) => {
+        id = toExecutable(id);
+        try {
+            execCmd(`scoreboard objectives add ${id} dummy`);
+            execCmd(`scoreboard objectives remove ${id}`);
+            return false;
+        }
+        catch {
+            return true;
+        }
+    };
+    static for = (id, displayName = id) => new objective(id, displayName, objective.exist(id));
+    static delete = (id) => {
+        try {
+            execCmd(`scoreboard objectives remove ${id}`);
+            return true;
+        }
+        catch {
+            return false;
+        }
+    };
+    id;
+    executableId;
+    dummies;
+    players;
+    display;
+    constructor(id, displayName = id, edit = false) {
+        if (id.length > 16)
+            throw new RangeError(`Objective identifier cannot go more than 16 characters`);
+        const execId = toExecutable(id);
+        const exist = objective.exist(id);
+        if (edit) {
+            if (!exist)
+                throw new ReferenceError(`Objective '${id}' not found`);
+        }
+        else {
+            if (exist)
+                throw new ReferenceError(`Objective '${id}' has already been created`);
+            if (displayName.length > 16)
+                throw new RangeError(`Objective display name cannot go more than 32 characters`);
+            const execDisplayName = toExecutable(displayName);
+            execCmd(`scoreboard objectives add ${execId} dummy ${execDisplayName}`);
+        }
+        this.id = id;
+        this.executableId = execId;
+        this.display = new display(auth, execId);
+        this.dummies = new dummies(auth, this);
+        this.players = new players(auth, this);
+    }
+}
+class display {
+    static 'set' = (target, obj) => {
+        const id = typeof obj == 'string' ? toExecutable(obj) : obj.executableId;
+        execCmd(`scoreboard objectives setdisplay ${target} ${id}`);
+    };
+    static clear = (target) => {
+        execCmd(`scoreboard objectives setdisplay ${target}`);
+    };
+    'set';
+    clear;
+    constructor(key, obj) {
+        if (key !== auth)
+            throw new ReferenceError('Class is not constructable');
+        const id = typeof obj == 'string' ? toExecutable(obj) : obj.executableId;
+        this.set = (target) => void execCmd(`scoreboard objectives setdisplay ${target} ${id}`);
+        this.clear = (target) => void execCmd(`scoreboard objectives setdisplay ${target}`);
+    }
+}
+export default class scoreboard {
+    static objective = objective;
+    static objectives = objective;
+    static display = display;
+    constructor() { throw new ReferenceError(`Class is not constructable`); }
+}


### PR DESCRIPTION
- Added AntiReach module.
Warns staff if the attacker hits another player from 3 blocks or further (can be configured)

- Added FixedContainer module
This resets the block container everytime the block is placed. For chest and trapped chest, both container can be checked for items and will be warned if the placed chest isn't empty.

- Added Scoreboard and Area library
- Added `eval`, `tps`, and `inv` command
- Disabled `inventory` commmand